### PR TITLE
Fix syntax issue preventing plugin activation

### DIFF
--- a/wc-password-strength-settings.php
+++ b/wc-password-strength-settings.php
@@ -51,7 +51,7 @@ if(!defined('WCPSS_VAR_PREFIX')) {
 define( 'project_domain', 'https://danielsantoro.com' );
 define( 'analytics_source', '?utm_source=pw-strength-plugin&utm_medium=plugin-overview-link' );
 define( 'github', 'https://github.com/DanielSantoro/wc-password-strength-settings/' );
-define( 'donate', 'https://www.paypal.me/dannysantoro')
+define( 'donate', 'https://www.paypal.me/dannysantoro');
 function wcpss_add_plugin_links( $links ) {
     $new_links = '<a href="'.github.'wiki/Documentation/" target="_blank">' . __( 'Documentation' ) . '</a>' . ' | ' . '<a href="'.project_domain.'/support/'.analytics_source.'" target="_blank">' . __( 'Contact Support' ) . '</a>' . ' | ' . '<a href="'.donate.'" target="_blank">' . __( 'Donate' ) . '</a>';
     array_push( $links, $new_links );


### PR DESCRIPTION
The lack of a semi-colon prevented the plugin from being activated